### PR TITLE
Remove `private` field to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name"           : "keystone-v3-client",
     "description"    : "A Node.js client for the OpenStack Keystone V3 Identity service",
-    "private"        : true,
     "version"        : "0.0.8",
     "keywords"       : [
         "keystone",


### PR DESCRIPTION
`private` field is used to prevent publishing the package [1].

[1] https://docs.npmjs.com/files/package.json#private